### PR TITLE
Reject the error instead of nothing

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -76,8 +76,8 @@ Client.prototype.connect = function (timeout) {
 			self.emit('close', hadError);
 		});
 
-		self.on('error', function () {
-			reject();
+		self.on('error', function (err) {
+			reject(err);
 		});
 
 		self.on('connect', function () {


### PR DESCRIPTION
When trying to display the error in case of an error, the promise rejection is empty. Thus, it is not possible to understand the problem.